### PR TITLE
Update text content type to match uikit and swiftui

### DIFF
--- a/Sources/Components/FormatStartTextField.swift
+++ b/Sources/Components/FormatStartTextField.swift
@@ -221,7 +221,7 @@ public struct FormatStartTextField: UIViewRepresentable {
     }
 
     // textContentType
-    public func textContentType(_ type: UITextContentType) -> Self {
+    public func textContentType(_ type: UITextContentType?) -> Self {
         var view = self
         view.textContentType = type
         return view

--- a/Sources/Components/FormatSumTextField.swift
+++ b/Sources/Components/FormatSumTextField.swift
@@ -248,7 +248,7 @@ public struct FormatSumTextField: UIViewRepresentable {
     }
     
     // textContentType
-    public func textContentType(_ type: UITextContentType) -> Self {
+    public func textContentType(_ type: UITextContentType?) -> Self {
         var view = self
         view.textContentType = type
         return view

--- a/Sources/Components/FormatTextField.swift
+++ b/Sources/Components/FormatTextField.swift
@@ -228,10 +228,9 @@ public struct FormatTextField: UIViewRepresentable {
     }
     
     // textContentType
-    public func textContentType(_ type: UITextContentType) -> Self {
+    public func textContentType(_ type: UITextContentType?) -> Self {
         var view = self
         view.textContentType = type
-        print("Updated text content type")
         return view
     }
     


### PR DESCRIPTION
Text content type should be optional so it matches function signature and overrides